### PR TITLE
Fix: Not start the performance test project using Nancy

### DIFF
--- a/Performance/Nancy/Nancy.csproj
+++ b/Performance/Nancy/Nancy.csproj
@@ -11,8 +11,8 @@
     <ProjectTypeGuids>{349c5851-65df-11da-9384-00065b846f21};{fae04ec0-301f-11d3-bf4b-00c04f79efbc}</ProjectTypeGuids>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Nancy</RootNamespace>
-    <AssemblyName>Nancy</AssemblyName>
+    <RootNamespace>Nancyfx</RootNamespace>
+    <AssemblyName>Nancyfx</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />

--- a/Performance/Nancy/Startup.cs
+++ b/Performance/Nancy/Startup.cs
@@ -1,16 +1,13 @@
-﻿using Owin;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Web;
+﻿using Nancy;
+using Owin;
 
-namespace Nancy
+namespace Nancyfx
 {
     public class Startup
     {
         public void Configuration(IAppBuilder app)
         {
-            app.UseNancy(new Owin.NancyOptions
+            app.UseNancy(new Nancy.Owin.NancyOptions
             {
                 Bootstrapper = new DefaultNancyBootstrapper()
             });
@@ -23,7 +20,7 @@ namespace Nancy
         {
             Get["/{name}/{x}/{y}"] = (x) =>
             {
-                return new MyClass { Name = x.name, Sum = x.x + x.y };
+                return Response.AsJson(new MyClass { Name = x.name, Sum = (int) x.x + (int) x.y });
             };
         }
     }

--- a/Performance/Nancy/Web.config
+++ b/Performance/Nancy/Web.config
@@ -8,14 +8,8 @@
 <configuration>
   <system.web>
     <compilation debug="true" targetFramework="4.0" />
-    <httpHandlers>
-      <add verb="*" type="Nancy.Hosting.Aspnet.NancyHttpRequestHandler" path="*" />
-    </httpHandlers>
   </system.web>
   <system.webServer>
     <validation validateIntegratedModeConfiguration="false" />
-    <handlers>
-      <add name="Nancy" verb="*" type="Nancy.Hosting.Aspnet.NancyHttpRequestHandler" path="*" />
-    </handlers>
   </system.webServer>
 </configuration>


### PR DESCRIPTION
For two reasons, I did not start the performance test project using Nancy.
1. This project name is 'Nancy', and output DLL file name is 'Nancy.dll'. This name is same as DLL name of NancyFx. So it was mistakenly overwrite the file.
2. There included settings of hosting on ASP.NET to Web.config.

And, I was implementing to return a JSON response.
